### PR TITLE
3 modification to latex table costruction

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,13 +113,14 @@ print(
         axis=C.ROW,
         count_vals=2,
         precision=0,
+        hline=2
     )
 )
 ```
 ```
-Attempt 1 & \bf{5} & 4 & 2 & \bf{3} \\
-Attempt 2 & \bf{9} & 6 & \bf{9} & 6 \\
-Attempt 3 & \bf{1} & 0 & 0 & \bf{1} \\
+Attempt 1 & \bf{5} & 4 & 2 & \bf{3} \\ 
+Attempt 2 & \bf{9} & 6 & \bf{9} & 6 \\ \hline
+Attempt 3 & \bf{1} & 0 & 0 & \bf{1} \\ 
 ```
 
 ### files

--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ fig, ax = up.get_line_plot(
  
 #### methods:
  * `print_latex_table`: creates a latex table of a dataset
- * `create_table`: creates a text table of a dataset
+ * `print_text_table`: creates a text table of a dataset
 
 #### example
 Create a latex table of a given dataset and highlight the maximum value every two values in the same row

--- a/utils_unibs/tables.py
+++ b/utils_unibs/tables.py
@@ -26,7 +26,7 @@ def get_idxs(position: int, count_vals: int):
 
 
 def print_latex_table(
-    dataset: list, labels: list = None, best=-1, axis: int = 0, count_vals: int = -1, precision: int = 1
+    dataset: list, labels: list = None, best=-1, axis: int = 0, count_vals: int = -1, precision: int = 1, hline: int = 0
 ):
     """
     Creates a latex table of a given dataset
@@ -39,6 +39,7 @@ def print_latex_table(
         count_vals: An integer representing the length of the interval within which to compute the best value.
                     Value -1 represents the whole axis.
         precision: an int that contains the float precision. Default is 1
+        hline: an int that contains the number of rows after which to put an horizontal line. Default is 0
 
     Returns:
         A string that contains the latex body of the given dataset
@@ -89,12 +90,14 @@ def print_latex_table(
             s += " & "
         s = s[:-2]
         s += r"\\"
+        if hline > 0 and i%hline == hline-1:
+            s += '\hline'
         s += "\n"
     return s
 
 
 def create_table(
-    title: str, headers: list, rows: list, just: int = 10, precision: int = 2
+    title: str, headers: list, rows: list, just: int = 10, precision: int = 2, hline: int = 0
 ) -> list:
     """
     Create a text table that contains the given rows

--- a/utils_unibs/tables.py
+++ b/utils_unibs/tables.py
@@ -25,6 +25,15 @@ def get_idxs(position: int, count_vals: int):
     return prev_idx, next_idx
 
 
+def _get_formatted_element(el: object, precision: int = 1):
+    try:
+        f = float(el)
+        return f"{f:.{precision}f}"
+    except ValueError:
+        s = str(el)
+        return f'{s}'
+
+
 def print_latex_table(
     dataset: list, labels: list = None, best=-1, axis: int = 0, count_vals: int = -1, precision: int = 1, hline: int = 0
 ):
@@ -59,30 +68,34 @@ def print_latex_table(
 
         try:
             if labels is not None:
-                s += f"{labels[i]} & "
+                s += _get_formatted_element(labels[i])
             else:
                 raise IndexError
         except IndexError:
-            s += " & "
+            pass
+        s += " & "
 
         for j, el in enumerate(r):
-            if best == 0 or best == 1:
-                if axis == C.COLUMN:
-                    prev_idx, next_idx = get_idxs(i, count_vals)
-                    max_idxs = np.where(
-                        table[:, j] == function(table[prev_idx:next_idx, j])
-                    )[0]
-                elif axis == C.ROW:
-                    prev_idx, next_idx = get_idxs(j, count_vals)
-                    max_idxs = np.where(
-                        table[i] == function(table[i, prev_idx:next_idx])
-                    )[0]
+            try:
+                if best == 0 or best == 1:
+                    if axis == C.COLUMN:
+                        prev_idx, next_idx = get_idxs(i, count_vals)
+                        max_idxs = np.where(
+                            table[:, j] == function(table[prev_idx:next_idx, j])
+                        )[0]
+                    elif axis == C.ROW:
+                        prev_idx, next_idx = get_idxs(j, count_vals)
+                        max_idxs = np.where(
+                            table[i] == function(table[i, prev_idx:next_idx])
+                        )[0]
+            except Exception as e:
+                max_idxs = []
 
             if (axis == C.COLUMN and i in max_idxs) or (
                 axis == C.ROW and j in max_idxs
             ):
                 s += r"\bf{"
-            s += f"{el:.{precision}f}"
+            s += _get_formatted_element(el, precision)
             if (axis == C.COLUMN and i in max_idxs) or (
                 axis == C.ROW and j in max_idxs
             ):
@@ -96,9 +109,8 @@ def print_latex_table(
     return s
 
 
-def create_table(
-    title: str, headers: list, rows: list, just: int = 10, precision: int = 2, hline: int = 0
-) -> list:
+def print_text_table(
+    title: str, headers: list, rows: list, just: int = 10, precision: int = 2) -> list:
     """
     Create a text table that contains the given rows
 

--- a/utils_unibs/tables.py
+++ b/utils_unibs/tables.py
@@ -1,5 +1,6 @@
 from utils_unibs.constants import C
 import numpy as np
+import re
 
 
 def get_idxs(position: int, count_vals: int):
@@ -25,17 +26,56 @@ def get_idxs(position: int, count_vals: int):
     return prev_idx, next_idx
 
 
+def _tex_escape(text):
+    """
+    Source: https://stackoverflow.com/questions/16259923/how-can-i-escape-latex-special-characters-inside-django-templates
+
+    Args:
+        text: a plain text message
+
+    Returns:
+        the message escaped to appear correctly in LaTeX
+    """
+    conv = {
+        "&": r"\&",
+        "%": r"\%",
+        "$": r"\$",
+        "#": r"\#",
+        "_": r"\_",
+        "{": r"\{",
+        "}": r"\}",
+        "~": r"\textasciitilde{}",
+        "^": r"\^{}",
+        "\\": r"\textbackslash{}",
+        "<": r"\textless{}",
+        ">": r"\textgreater{}",
+    }
+    regex = re.compile(
+        "|".join(
+            re.escape(str(key))
+            for key in sorted(conv.keys(), key=lambda item: -len(item))
+        )
+    )
+    return regex.sub(lambda match: conv[match.group()], text)
+
+
 def _get_formatted_element(el: object, precision: int = 1):
     try:
         f = float(el)
         return f"{f:.{precision}f}"
     except ValueError:
         s = str(el)
-        return f'{s}'
+        return f"{_tex_escape(s)}"
 
 
 def print_latex_table(
-    dataset: list, labels: list = None, best=-1, axis: int = 0, count_vals: int = -1, precision: int = 1, hline: int = 0
+    dataset: list,
+    labels: list = None,
+    best=-1,
+    axis: int = 0,
+    count_vals: int = -1,
+    precision: int = 1,
+    hline: int = 0,
 ):
     """
     Creates a latex table of a given dataset
@@ -103,14 +143,15 @@ def print_latex_table(
             s += " & "
         s = s[:-2]
         s += r"\\"
-        if hline > 0 and i%hline == hline-1:
-            s += '\hline'
+        if hline > 0 and i % hline == hline - 1:
+            s += "\hline"
         s += "\n"
     return s
 
 
 def print_text_table(
-    title: str, headers: list, rows: list, just: int = 10, precision: int = 2) -> list:
+    title: str, headers: list, rows: list, just: int = 10, precision: int = 2
+) -> list:
     """
     Create a text table that contains the given rows
 

--- a/utils_unibs/tests/table_tests.py
+++ b/utils_unibs/tests/table_tests.py
@@ -18,8 +18,9 @@ class TestGetID(unittest.TestCase):
 class TestPrintLatexTable(unittest.TestCase):
 
     x = [[1, 2, 3], [1, 2, 3]]
-    x1 = [[1, 2, 'c'], ['1', 'b', 4]]
+    x_string = [[1, 2, "c"], ["1%", "b", 4]]
     labels = ["a", "b"]
+    labels_special = ["a>b", "a & b ~ c"]
 
     def test_correct(self):
         sol = " & 1 & 2 & 3 \\\\\\hline\n & 1 & 2 & 3 \\\\\\hline\n"
@@ -48,15 +49,41 @@ class TestPrintLatexTable(unittest.TestCase):
         self.assertEqual(
             print_latex_table(dataset=self.x, best=0, axis=0, precision=0), sol
         )
-        self.assertEqual(print_latex_table(dataset=self.x, precision=0, best=0, axis=0, count_vals=-1), sol)
-        self.assertEqual(print_latex_table(dataset=self.x, precision=0, best=0, axis=0, count_vals=0), sol)
+        self.assertEqual(
+            print_latex_table(
+                dataset=self.x, precision=0, best=0, axis=0, count_vals=-1
+            ),
+            sol,
+        )
+        self.assertEqual(
+            print_latex_table(
+                dataset=self.x, precision=0, best=0, axis=0, count_vals=0
+            ),
+            sol,
+        )
         sol = "a & 1 & 2 & 3 \\\\\nb & 1 & 2 & 3 \\\\\n"
         self.assertEqual(
             print_latex_table(dataset=self.x, precision=0, hline=0, labels=self.labels),
             sol,
         )
-        sol = ' & 1 & 2 & c \\\\\n & 1 & b & 4 \\\\\n'
-        self.assertEqual(print_latex_table(dataset=self.x1, precision=0), sol)
-        self.assertEqual(print_latex_table(dataset=self.x1, precision=0, best=0, axis=0, count_vals=0), sol)
-        self.assertEqual(print_latex_table(dataset=self.x1, precision=0, best=1, axis=C.ROW, count_vals=2), sol)
-
+        sol = " & 1 & 2 & c \\\\\n & 1\\% & b & 4 \\\\\n"
+        self.assertEqual(print_latex_table(dataset=self.x_string, precision=0), sol)
+        self.assertEqual(
+            print_latex_table(
+                dataset=self.x_string, precision=0, best=0, axis=0, count_vals=0
+            ),
+            sol,
+        )
+        self.assertEqual(
+            print_latex_table(
+                dataset=self.x_string, precision=0, best=1, axis=C.ROW, count_vals=2
+            ),
+            sol,
+        )
+        sol = "a\\textgreater{}b & 1 & 2 & c \\\\\na \\& b \\textasciitilde{} c & 1\\% & b & 4 \\\\\n"
+        self.assertEqual(
+            print_latex_table(
+                dataset=self.x_string, precision=0, labels=self.labels_special
+            ),
+            sol,
+        )

--- a/utils_unibs/tests/table_tests.py
+++ b/utils_unibs/tests/table_tests.py
@@ -10,20 +10,46 @@ class TestGetID(unittest.TestCase):
         self.assertEqual(get_idxs(1, 5), (0, 5))
 
     def test_unknown(self):
-        self.assertEqual(get_idxs(1,8), (0, 8))
+        self.assertEqual(get_idxs(1, 8), (0, 8))
         self.assertEqual(get_idxs(4, 20), (0, 20))
 
 
 class TestPrintLatexTable(unittest.TestCase):
 
-    x = [[1,2,3], [1,2,3]]
+    x = [[1, 2, 3], [1, 2, 3]]
+    labels = ["a", "b"]
 
     def test_correct(self):
-        sol = ' & 1 & 2 & 3 \\\\\\hline\n & 1 & 2 & 3 \\\\\\hline\n'
+        sol = " & 1 & 2 & 3 \\\\\\hline\n & 1 & 2 & 3 \\\\\\hline\n"
         self.assertEqual(print_latex_table(dataset=self.x, precision=0, hline=1), sol)
-        sol = ' & 1 & 2 & 3 \\\\\n & 1 & 2 & 3 \\\\\n'
+        sol = " & 1 & 2 & 3 \\\\\n & 1 & 2 & 3 \\\\\n"
         self.assertEqual(print_latex_table(dataset=self.x, precision=0, hline=0), sol)
         self.assertEqual(print_latex_table(dataset=self.x, precision=0, hline=-1), sol)
         self.assertEqual(print_latex_table(dataset=self.x, precision=0, hline=5), sol)
-        sol = ' & 1 & 2 & 3 \\\\\n & 1 & 2 & 3 \\\\\\hline\n'
+        sol = " & 1 & 2 & 3 \\\\\n & 1 & 2 & 3 \\\\\\hline\n"
         self.assertEqual(print_latex_table(dataset=self.x, precision=0, hline=2), sol)
+        sol = " & 1.000 & 2.000 & 3.000 \\\\\n & 1.000 & 2.000 & 3.000 \\\\\n"
+        self.assertEqual(print_latex_table(dataset=self.x, precision=3, hline=0), sol)
+        sol = " & 1 & \\bf{2} & \\bf{3} \\\\\n & 1 & \\bf{2} & \\bf{3} \\\\\n"
+        self.assertEqual(
+            print_latex_table(
+                dataset=self.x, best=0, axis=1, count_vals=2, precision=0
+            ),
+            sol,
+        )
+        sol = (
+            " & \\bf{1} & \\bf{2} & \\bf{3} \\\\\n & \\bf{1} & \\bf{2} & \\bf{3} \\\\\n"
+        )
+        self.assertEqual(
+            print_latex_table(dataset=self.x, best=1, axis=0, precision=0), sol
+        )
+        self.assertEqual(
+            print_latex_table(dataset=self.x, best=0, axis=0, precision=0), sol
+        )
+        self.assertEqual(print_latex_table(dataset=self.x, precision=0, best=0, axis=0, count_vals=-1), sol)
+        self.assertEqual(print_latex_table(dataset=self.x, precision=0, best=0, axis=0, count_vals=0), sol)
+        sol = "a & 1 & 2 & 3 \\\\\nb & 1 & 2 & 3 \\\\\n"
+        self.assertEqual(
+            print_latex_table(dataset=self.x, precision=0, hline=0, labels=self.labels),
+            sol,
+        )

--- a/utils_unibs/tests/table_tests.py
+++ b/utils_unibs/tests/table_tests.py
@@ -1,14 +1,29 @@
 import unittest
-from utils_unibs.tables import get_idxs
+from utils_unibs.tables import get_idxs, print_latex_table
 
 
 class TestGetID(unittest.TestCase):
     def test_correct(self):
-        self.assertEqual(get_idxs(1, 0, 3, [8, 5]), (0, 3))
-        self.assertEqual(get_idxs(5, 1, 3, [8, 5]), (3, 6))
-        self.assertEqual(get_idxs(1, 1, -1, [5, 3]), (0, 3))
-        self.assertEqual(get_idxs(1, 0, -1, [5, 3]), (0, 5))
+        self.assertEqual(get_idxs(1, 3), (0, 3))
+        self.assertEqual(get_idxs(5, 3), (3, 6))
+        self.assertEqual(get_idxs(1, 3), (0, 3))
+        self.assertEqual(get_idxs(1, 5), (0, 5))
 
     def test_unknown(self):
-        self.assertEqual(get_idxs(1, 0, 0, [8, 5]), (0, 8))
-        self.assertEqual(get_idxs(4, 0, 20, [10, 4]), (0, 20))
+        self.assertEqual(get_idxs(1,8), (0, 8))
+        self.assertEqual(get_idxs(4, 20), (0, 20))
+
+
+class TestPrintLatexTable(unittest.TestCase):
+
+    x = [[1,2,3], [1,2,3]]
+
+    def test_correct(self):
+        sol = ' & 1 & 2 & 3 \\\\\\hline\n & 1 & 2 & 3 \\\\\\hline\n'
+        self.assertEqual(print_latex_table(dataset=self.x, precision=0, hline=1), sol)
+        sol = ' & 1 & 2 & 3 \\\\\n & 1 & 2 & 3 \\\\\n'
+        self.assertEqual(print_latex_table(dataset=self.x, precision=0, hline=0), sol)
+        self.assertEqual(print_latex_table(dataset=self.x, precision=0, hline=-1), sol)
+        self.assertEqual(print_latex_table(dataset=self.x, precision=0, hline=5), sol)
+        sol = ' & 1 & 2 & 3 \\\\\n & 1 & 2 & 3 \\\\\\hline\n'
+        self.assertEqual(print_latex_table(dataset=self.x, precision=0, hline=2), sol)

--- a/utils_unibs/tests/table_tests.py
+++ b/utils_unibs/tests/table_tests.py
@@ -1,5 +1,6 @@
 import unittest
 from utils_unibs.tables import get_idxs, print_latex_table
+from utils_unibs.constants import C
 
 
 class TestGetID(unittest.TestCase):
@@ -17,6 +18,7 @@ class TestGetID(unittest.TestCase):
 class TestPrintLatexTable(unittest.TestCase):
 
     x = [[1, 2, 3], [1, 2, 3]]
+    x1 = [[1, 2, 'c'], ['1', 'b', 4]]
     labels = ["a", "b"]
 
     def test_correct(self):
@@ -53,3 +55,8 @@ class TestPrintLatexTable(unittest.TestCase):
             print_latex_table(dataset=self.x, precision=0, hline=0, labels=self.labels),
             sol,
         )
+        sol = ' & 1 & 2 & c \\\\\n & 1 & b & 4 \\\\\n'
+        self.assertEqual(print_latex_table(dataset=self.x1, precision=0), sol)
+        self.assertEqual(print_latex_table(dataset=self.x1, precision=0, best=0, axis=0, count_vals=0), sol)
+        self.assertEqual(print_latex_table(dataset=self.x1, precision=0, best=1, axis=C.ROW, count_vals=2), sol)
+


### PR DESCRIPTION
# **Todo**:

- [x] Handle non float data
- [x] Add \\hline
- [x] Add escape for special characters
- [x] #3 

### **Minor changes**
- Refactor `create_table` to `print_text_table` for better consistency


## **Handle non float data**
**Is your feature request related to a problem? Please describe.**
Latex table only works with `float` data type. e.g. I get format error every time I insert `str` data type it raises 
```python
Unknown format code 'f' for object of type 'numpy.str_'
```

**Describe the solution**
Moved formatting to a separate function that can handle striking types 
No max or min highlight when the dataset contains a string. The whole dataset is cast to `str` so `np.max` or `np.min' do not work
Add some tests for this new functionality.

## **Add \\hline**
**Is your feature request related to a problem? Please describe.**
After creating a LaTeX table I have to add `\hline` manually after each row

**Describe the solution**
Add an `hline` parameter in `print_latex_table` method. This parameter allows you to select the number of lines between each `\hline` LaTeX command
Add some test for this new parameter.


## **Add escape for special characters**
**Is your feature request related to a problem? Please describe.**
When adding strings in labels that contain special characters such as *%*, *&*, etc. it causes compilation problems in the LaTex editor.

**Describe the solution**
Add new function `_escape_tex` to escape LaTeX special characters
Add some test for this new feature

